### PR TITLE
add a second cron to update at 5pm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
     triggers:
       - schedule:
           # Midnight PST is 8am UTC
-          cron: "0 8 * * *","0 17 * * *"
+          cron: "0 8 , 17 * * *"
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
     triggers:
       - schedule:
           # Midnight PST is 8am UTC
-          cron: "0 8 * * *"
+          cron: "0 8 * * *","0 17 * * *"
           filters:
             branches:
               only: master


### PR DESCRIPTION
the city currently queries/updates data from arbor access at 4am and 4pm. this PR adds a second cron at 5pm so that the map is updated to the city's data twice a day