### PR TITLE
add ipc status to "native" field

### DIFF
--- a/data/species_attributes.csv
+++ b/data/species_attributes.csv
@@ -1,9 +1,9 @@
 botanical_name,common_name,Species ID,family_botanical_name,family_common_name,native,EOL_ID,EOL_overview_URL,simplified_IUCN_status,IUCN_status,IUCN_DOI_or_URL,shade_production,form,type,Cal_IPC_rating,CAL_IPC_url,Irrigation_Requirements
-Acacia baileyana,BAILEY ACACIA,144,Fabaceae,Legume,exotic,649008,http://eol.org/pages/649008/overview,not listed,not listed,,dense,spreading,evergreen,watch,https://www.cal-ipc.org/plants/risk/acacia-baileyana-risk/,"none, once established"
-Acacia baileyana 'Purpurea',Purple Acacia,1102,Fabaceae,Legume,exotic,649008,http://eol.org/pages/649008/overview,not listed,not listed,,dense,spreading,evergreen,watch,https://www.cal-ipc.org/plants/risk/acacia-baileyana-risk/,"none, once established"
+Acacia baileyana,BAILEY ACACIA,144,Fabaceae,Legume,watch,649008,http://eol.org/pages/649008/overview,not listed,not listed,,dense,spreading,evergreen,watch,https://www.cal-ipc.org/plants/risk/acacia-baileyana-risk/,"none, once established"
+Acacia baileyana 'Purpurea',Purple Acacia,1102,Fabaceae,Legume,watch,649008,http://eol.org/pages/649008/overview,not listed,not listed,,dense,spreading,evergreen,watch,https://www.cal-ipc.org/plants/risk/acacia-baileyana-risk/,"none, once established"
 Acacia cognata,River Wattle,274,Fabaceae,Legume,exotic,660740,http://eol.org/pages/660740/overview,not listed,not listed,,dense,"small, spreading",,,,
 Acacia longifolia,Sydney Golden Wattle,338,Fabaceae,Legume,exotic,690308,http://eol.org/pages/690308/overview,not listed,not listed,,dense,rounded,,,,
-Acacia melanoxylon,BLACK ACACIA,145,Fabaceae,Legume,exotic,8684941,http://eol.org/pages/8684941/overview,not listed,not listed,,dense,rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/acacia-melanoxylon-plant-assessment-form/,"none, once established"
+Acacia melanoxylon,BLACK ACACIA,145,Fabaceae,Legume,limited,8684941,http://eol.org/pages/8684941/overview,not listed,not listed,,dense,rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/acacia-melanoxylon-plant-assessment-form/,"none, once established"
 Acacia stenophylla,Shoestring Acacia,415,Fabaceae,Legume,exotic,643396,http://eol.org/pages/643396/overview,not listed,not listed,,filtered,"weeping, pendulous",,,,
 Acca sellowiana,Pinapple Guava,207,Myrtaceae,Myrtle,exotic,2508674,http://eol.org/pages/2508674/overview,not listed,not listed,,filtered,rounded,,,,
 Acer palmatum,JAPANESE MAPLE,188,Sapindaceae,Soapberry,exotic,596824,http://eol.org/pages/596824/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2017-3.RLTS.T193845A2285627.en,dense,"spreading, vase",,,,moderate
@@ -16,7 +16,7 @@ Afrocarpus gracilior,FERN PINE,46,Podocarpaceae,Podocarp,exotic,1033605,http://e
 Afrocarpus macrophyllus,YEW PINE,134,Podocarpaceae,Podocarp,exotic,1059922,http://eol.org/pages/1059922/overview,not listed,not listed,,dense,rounded,,,,
 Agathis robusta,Queensland Kauri,269,Araucariaceae,Araucaria,exotic,1033628,http://eol.org/pages/1033628/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2013-1.RLTS.T16437966A2960124.en,dense,rounded,,,,
 Agonis flexuosa,PEPPERMINT TREE,307,Myrtaceae,Myrtle,exotic,5448625,http://eol.org/pages/5448625/overview,not listed,not listed,,filtered,pendulous,,,,minimal
-Ailanthus altissima,TREE OF HEAVEN,233,Simaroubaceae,Quassia,exotic,5614169,http://eol.org/pages/5614169/overview,not listed,not listed,,dense,"spreading, vase",,moderate,https://www.cal-ipc.org/plants/paf/ailanthus-altissima-plant-assessment-form/,
+Ailanthus altissima,TREE OF HEAVEN,233,Simaroubaceae,Quassia,moderate,5614169,http://eol.org/pages/5614169/overview,not listed,not listed,,dense,"spreading, vase",,moderate,https://www.cal-ipc.org/plants/paf/ailanthus-altissima-plant-assessment-form/,
 Albizia julibrissin,SILK TREE,76,Fabaceae,Legume,exotic,640054,http://eol.org/pages/640054/overview,not listed,not listed,,filtered,rounded,deciduous,,,minimal
 Allocasuarina verticillata,Drooping She-Oak,1881,Casuarinaceae,Beefwood,exotic,628407,http://eol.org/pages/628407/overview,not listed,not listed,,filtered,"vase, pendulous",,,,
 Alnus cordata,ITALIAN ALDER,187,Betulaceae,Birch,exotic,1145955,http://eol.org/pages/1145955/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2017-3.RLTS.T194657A117268007.en,dense,"Conical, Spreading",,,,moderate
@@ -69,7 +69,7 @@ Cinnamomum camphora,CAMPHOR TREE,24,Lauraceae,Laurel,exotic,596902,http://eol.or
 Citrus limon,LEMON,66,Rutaceae,Rue,exotic,582200,http://eol.org/pages/582200/overview,not listed,not listed,,dense,rounded,evergreen,,,moderate
 Citrus sinensis,ORANGE,88,Rutaceae,Rue,exotic,582206,http://eol.org/pages/582206/overview,not listed,not listed,,dense,rounded,evergreen,,,moderate
 Cocculus laurifolius,LAUREL-LEAFED SNAILSEED,336,Menispermaceae,Moonseed,exotic,2886371,http://eol.org/pages/2886371/overview,not listed,not listed,,"filtered, dense",rounded,evergreen,,,
-Cordyline australis,DRACAENA,164,Asparagaceae,Asparagus,exotic,1087084,http://eol.org/pages/1087084/overview,not listed,not listed,,"little, none",palm,evergreen,limited,https://www.cal-ipc.org/plants/paf/cordyline-australis-plant-assessment-form/,moderate
+Cordyline australis,DRACAENA,164,Asparagaceae,Asparagus,limited,1087084,http://eol.org/pages/1087084/overview,not listed,not listed,,"little, none",palm,evergreen,limited,https://www.cal-ipc.org/plants/paf/cordyline-australis-plant-assessment-form/,moderate
 Corymbia citriodora,LEMON-SCENTED GUM,67,Myrtaceae,Myrtle,exotic,301375,http://eol.org/pages/301375/overview,not listed,not listed,,dense,rounded,,,,
 Corymbia ficifolia,RED FLOWERING GUM,101,Myrtaceae,Myrtle,exotic,301438,http://eol.org/pages/301438/overview,not listed,not listed,,dense,rounded,,,,
 Corymbia maculata,SPOTTED GUM,117,Myrtaceae,Myrtle,exotic,301463,http://eol.org/pages/301463/overview,not listed,not listed,,dense,rounded,,,,
@@ -91,13 +91,13 @@ Erythrina bidwillii,Bidwills Coral Tree,303,Fabaceae,Legume,exotic,49953463,http
 Erythrina caffra,KAFFIRBOOM CORAL TREE,193,Fabaceae,Legume,exotic,644148,http://eol.org/pages/644148/overview,not listed,not listed,,dense,spreading,,,,moderate
 Erythrina coralloides,NAKED CORAL TREE,308,Fabaceae,Legume,exotic,643189,http://eol.org/pages/643189/overview,not listed,not listed,,dense,spreading,,,,moderate
 Eucalyptus amplifolia,CABBAGE GUM,663,Myrtaceae,Myrtle,exotic,630154,http://eol.org/pages/630154/overview,not listed,not listed,,dense,"vase, rounded",,,,minimal
-Eucalyptus camaldulensis,RED GUM,102,Myrtaceae,Myrtle,exotic,301398,http://eol.org/pages/301398/overview,not listed,not listed,,"filtered, dense",rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/eucalyptus-camaldulensis-plant-assessment-form/,minimal
+Eucalyptus camaldulensis,RED GUM,102,Myrtaceae,Myrtle,limited,301398,http://eol.org/pages/301398/overview,not listed,not listed,,"filtered, dense",rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/eucalyptus-camaldulensis-plant-assessment-form/,minimal
 Eucalyptus cinerea,ASH GUM,219,Myrtaceae,Myrtle,exotic,630170,http://eol.org/pages/630170/overview,not listed,not listed,,filtered,rounded,evergreen,,,minimal
-Eucalyptus cladocalyx,SUGAR GUM,119,Myrtaceae,Myrtle,exotic,637218,http://eol.org/pages/637218/overview,not listed,not listed,,dense,"vase, rounded",,watch,https://www.cal-ipc.org/plants/risk/eucalyptus-cladocalyx-risk/,minimal
+Eucalyptus cladocalyx,SUGAR GUM,119,Myrtaceae,Myrtle,watch,637218,http://eol.org/pages/637218/overview,not listed,not listed,,dense,"vase, rounded",,watch,https://www.cal-ipc.org/plants/risk/eucalyptus-cladocalyx-risk/,minimal
 Eucalyptus cornuta,YATE,300,Myrtaceae,Myrtle,exotic,301420,https://eol.org/pages/301420/overview,not listed,not listed,,dense,"vase, rounded",,,,minimal
 Eucalyptus deglupta,Mindanao Gum,416,Myrtaceae,Myrtle,exotic,230366,http://eol.org/pages/230366/overview,not listed,not listed,,dense,"vase, rounded",,,,minimal
-Eucalyptus globulus,BLUE GUM,11,Myrtaceae,Myrtle,exotic,301421,http://eol.org/pages/301421/overview,not listed,not listed,,dense,rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/eucalyptus-globulus-plant-assessment-form/,minimal
-Eucalyptus globulus 'Compacta',Dwarf Blue Gum,445,Myrtaceae,Myrtle,exotic,301421,http://eol.org/pages/301421/overview,not listed,not listed,,dense,rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/eucalyptus-globulus-plant-assessment-form/,minimal
+Eucalyptus globulus,BLUE GUM,11,Myrtaceae,Myrtle,limited,301421,http://eol.org/pages/301421/overview,not listed,not listed,,dense,rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/eucalyptus-globulus-plant-assessment-form/,minimal
+Eucalyptus globulus 'Compacta',Dwarf Blue Gum,445,Myrtaceae,Myrtle,limited,301421,http://eol.org/pages/301421/overview,not listed,not listed,,dense,rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/eucalyptus-globulus-plant-assessment-form/,minimal
 Eucalyptus grandis,FLOODED GUM,351,Myrtaceae,Myrtle,exotic,230778,http://eol.org/pages/230778/overview,not listed,not listed,,dense,"vase, rounded",,,,minimal
 Eucalyptus lehmannii,BUSHY YATE,18,Myrtaceae,Myrtle,exotic,630174,http://eol.org/pages/630174/overview,not listed,not listed,,dense,spreading,evergreen,,,minimal
 Eucalyptus leucoxylon 'Rosea',LG.-FRUIT RED-FLOWERING GUM,909,Myrtaceae,Myrtle,exotic,301411,http://eol.org/pages/301411/overview,not listed,not listed,,"filtered, dense",rounded,evergreen,,,minimal
@@ -112,7 +112,7 @@ Eucalyptus viminalis,MANNA GUM,301,Myrtaceae,Myrtle,exotic,245551,http://eol.org
 Eugenia aggregata,Cherry Of The Rio Grande,1051,Myrtaceae,Myrtle,exotic,48306163,http://eol.org/pages/48306163/overview,not listed,not listed,,filtered,,,,,
 Ficus benjamina,WEEPING FIG,127,Moraceae,Mulberry,exotic,594918,http://eol.org/pages/594918/overview,not listed,not listed,,dense,"vase, rounded",evergeen,,,moderate
 Ficus benjamina 'Variegata',Chinese Weeping Banyan,1805,Moraceae,Mulberry,exotic,594918,http://eol.org/pages/594918/overview,not listed,not listed,,dense,"vase, rounded",evergreen,,,moderate
-Ficus carica,EDIBLE FIG,167,Moraceae,Mulberry,exotic,594632,http://eol.org/pages/594632/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2007.RLTS.T63527A12687229.en,dense,"rounded, spreading",deciduous,moderate,https://www.cal-ipc.org/plants/paf/ficus-carica-plant-assessment-form/,moderate
+Ficus carica,EDIBLE FIG,167,Moraceae,Mulberry,moderate,594632,http://eol.org/pages/594632/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2007.RLTS.T63527A12687229.en,dense,"rounded, spreading",deciduous,moderate,https://www.cal-ipc.org/plants/paf/ficus-carica-plant-assessment-form/,moderate
 Ficus elastica,RUBBER TREE,108,Moraceae,Mulberry,exotic,594821,http://eol.org/pages/594821/overview,not listed,not listed,,dense,"vase, rounded",,,,moderate
 Ficus lyrata,Fiddleleaf Fig,344,Moraceae,Mulberry,exotic,482014,http://eol.org/pages/482014/overview,not listed,not listed,,dense,"vase, rounded",,,,moderate
 Ficus macrophylla,MORETON BAY FIG,80,Moraceae,Mulberry,exotic,2876056,http://eol.org/pages/2876056/overview,not listed,not listed,,dense,rounded,evergreen,,,moderate
@@ -128,7 +128,7 @@ Geijera parviflora,AUSTRALIAN WILLOW,7,Rutaceae,Rue,exotic,5624115,http://eol.or
 Ginkgo biloba,MAIDENHAIR TREE,71,Ginkgoaceae,Ginko,exotic,1156278,http://eol.org/pages/1156278/overview,Endangered,Endangered B1+2c,http://dx.doi.org/10.2305/IUCN.UK.1998.RLTS.T32353A9700472.en,filtered,"conical, rounded",deciduous,,,minimal
 Ginkgo biloba 'Autumn Gold',GINKGO AUTUMN GOLD,1263,Ginkgoaceae,Ginko,exotic,1156278,http://eol.org/pages/1156278/overview,not listed,not listed,,filtered,"conical, rounded",deciduous,,,minimal
 Gleditsia triacanthos,HONEY LOCUST,55,Fabaceae,Legume,exotic,416265,http://eol.org/pages/416265/overview,not listed,not listed,,filtered,rounded,deciduous,,,
-Grevillea robusta,SILK OAK,112,Proteaceae,Protea,exotic,582736,http://eol.org/pages/582736/overview,not listed,not listed,,filtered,spreading,evergreen,watch,https://www.cal-ipc.org/plants/risk/grevillea-robusta-risk/,minimal
+Grevillea robusta,SILK OAK,112,Proteaceae,Protea,watch,582736,http://eol.org/pages/582736/overview,not listed,not listed,,filtered,spreading,evergreen,watch,https://www.cal-ipc.org/plants/risk/grevillea-robusta-risk/,minimal
 Hakea suaveolens,SWEET HAKEA,270,Proteaceae,Protea,exotic,5511103,http://eol.org/pages/5511103/overview,not listed,not listed,,filtered,rounded,,,,
 Handroanthus chrysotrichus,Golden Trumpet Tree,179,Bignoniaceae,Bignonia,exotic,5637482,http://eol.org/pages/5637482/overview,not listed,not listed,,dense,rounded,,,,
 Handroanthus impetiginosus,Pink Trumpet Tree,403,Bignoniaceae,Bignonia,exotic,5637444,http://eol.org/pages/5637444,not listed,not listed,,"filtered, dense","rounded, vase",deciduous,,,
@@ -155,9 +155,9 @@ Lagerstroemia indica 'Tuscarora',Tuscarora Crape Myrtle,1291,Lythraceae,Loosestr
 Lagerstroemia indica 'White',White Crape Myrtle,1290,Lythraceae,Loosestrife,exotic,582106,http://eol.org/pages/582106/overview,not listed,not listed,,filtered,rounded,deciduous,,,minimal
 Lagunaria patersonii,PRIMROSE TREE,210,Malvaceae,Mallow,exotic,586694,http://eol.org/pages/586694/overview,not listed,not listed,,dense,rounded,evergreen,,,minimal
 Laurus nobilis,SWEET BAY,121,Lauraceae,Laurel,exotic,486835,http://eol.org/pages/486835/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2018-1.RLTS.T203351A119996864.en,dense,conical,evergreen,,,minimal
-Leptospermum laevigatum,AUSTRALIAN TEA TREE,907,Myrtaceae,Myrtle,exotic,2508619,http://eol.org/pages/2508619/overview,not listed,not listed,,dense,rounded,,watch,https://www.cal-ipc.org/plants/risk/leptospermum-laevigatum-risk/,minimal
+Leptospermum laevigatum,AUSTRALIAN TEA TREE,907,Myrtaceae,Myrtle,watch,2508619,http://eol.org/pages/2508619/overview,not listed,not listed,,dense,rounded,,watch,https://www.cal-ipc.org/plants/risk/leptospermum-laevigatum-risk/,minimal
 Leptospermum spp.,Tea Tree,255,Myrtaceae,Myrtle,exotic,2508616,http://eol.org/pages/2508616/overview,not listed,not listed,,dense,rounded,,,,minimal
-Ligustrum lucidum,GLOSSY PRIVET,48,Oleaceae,Olive,exotic,487035,http://eol.org/pages/487035/overview,not listed,not listed,,dense,rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/ligustrum-lucidum-plant-assessment-form/,
+Ligustrum lucidum,GLOSSY PRIVET,48,Oleaceae,Olive,limited,487035,http://eol.org/pages/487035/overview,not listed,not listed,,dense,rounded,evergreen,limited,https://www.cal-ipc.org/plants/paf/ligustrum-lucidum-plant-assessment-form/,
 Liquidambar formosana,Chinese Sweetgum,158,Altingiaceae,Sweet-gum,exotic,2887420,http://eol.org/pages/2887420/overview,Least Concern,Least Concern,http://www.iucnredlist.org/details/61983495/0,dense,columnar,deciduous,,,
 Liquidambar styraciflua,AMERICAN SWEETGUM,5,Altingiaceae,Sweet-gum,exotic,594658,http://eol.org/pages/594658/overview,Least Concern,Least Concern,http://www.iucnredlist.org/details/33966/0,dense,"columnar, rounded",deciduous,,,moderate
 Liquidambar styraciflua 'Rotundiloba',ROUND-LEAFED SWEETGUM,340,Altingiaceae,Sweet-gum,exotic,594658,http://eol.org/pages/594658/overview,not listed,not listed,,dense,"columnar, rounded",deciduous,,,moderate
@@ -174,7 +174,7 @@ Magnolia grandiflora 'Little Gem',Little Gem Magnolia,607,Magnoliaceae,Magnolia,
 Magnolia grandiflora 'Samuel Sommer',SAMUEL SOMMER MAGNOLIA,392,Magnoliaceae,Magnolia,exotic,1154991,http://eol.org/pages/1154991/overview,not listed,not listed,,dense,"rounded, spreading",evergreen,,,moderate
 Malus floribunda,Crabapple,37,Rosaceae,Rose,exotic,11168049,https://eol.org/pages/11168049,not listed,not listed,,dense,spreading,deciduous,,,
 Malus sylvestris,EDIBLE APPLE,42,Rosaceae,Rose,exotic,633316,http://eol.org/pages/633316/overview,Data Deficient,Data Deficient,http://dx.doi.org/10.2305/IUCN.UK.2011-1.RLTS.T172170A6841688.en,dense,rounded,,,,moderate
-Maytenus boaria,MAYTEN TREE,196,Celastraceae,Bittersweet,exotic,6940183,http://eol.org/pages/6940183/overview,not listed,not listed,,filtered,pendulous,evergreen,watch,https://www.cal-ipc.org/plants/risk/maytenus-boaria-risk/,moderate
+Maytenus boaria,MAYTEN TREE,196,Celastraceae,Bittersweet,watch,6940183,http://eol.org/pages/6940183/overview,not listed,not listed,,filtered,pendulous,evergreen,watch,https://www.cal-ipc.org/plants/risk/maytenus-boaria-risk/,moderate
 Melaleuca armillaris,Drooping Melaleuca,352,Myrtaceae,Myrtle,exotic,5449241,http://eol.org/pages/5449241/overview,not listed,not listed,,"filtered, dense",rounded,evergreen,,,minimal
 Melaleuca citrina,LEMON BOTTLEBRUSH,13,Myrtaceae,Myrtle,exotic,2508464,http://eol.org/pages/2508464/overview,not listed,not listed,,,,,,,
 Melaleuca ericifolia,Heath Melaleuca,256,Myrtaceae,Myrtle,exotic,5449388,http://eol.org/pages/5449388/overview,not listed,not listed,,dense,pendulous,,,,minimal
@@ -189,19 +189,19 @@ Metrosideros excelsus,NEW ZEALAND CHRISTMAS TREE,82,Myrtaceae,Myrtle,exotic,5448
 Morus alba,WHITE MULBERRY,130,Moraceae,Mulberry,exotic,594885,http://eol.org/pages/594885/overview,not listed,not listed,,dense,"rounded, spreading",evergreen,,,moderate
 Morus spp.,Mulberry Species,1331,Moraceae,Mulberry,exotic,72690,https://eol.org/pages/72690,not listed,not listed,,,,,,,
 Musa spp.,BANANA,320,Musaceae,Banana,exotic,44527,http://eol.org/pages/44527/overview,not listed,not listed,,,,,,,high
-Myoporum laetum,MYOPORUM,81,Scrophulariaceae,Figwort,exotic,578077,http://eol.org/pages/578077/overview,not listed,not listed,,dense,spreading,evergreen,moderate,https://www.cal-ipc.org/plants/profile/myoporum-laetum-profile/,"none, once established"
+Myoporum laetum,MYOPORUM,81,Scrophulariaceae,Figwort,moderate,578077,http://eol.org/pages/578077/overview,not listed,not listed,,dense,spreading,evergreen,moderate,https://www.cal-ipc.org/plants/profile/myoporum-laetum-profile/,"none, once established"
 Myrtus communis,TRUE MYRTLE,318,Myrtaceae,Myrtle,exotic,2508590,http://eol.org/pages/2508590/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2018-1.RLTS.T203365A119997141.en.,dense,conical,evergreen,,,minimal
 Nerium oleander,OLEANDER,86,Apocynaceae,Dogbane,exotic,581314,http://eol.org/pages/581314/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2013-1.RLTS.T202961A13537523.en,little,rounded,evergreen,,,minimal
 No Replant,No Replant,1420,,,,,,not listed,not listed,,,,,,,
 Nolina recurvata,PONYTAIL PALM,361,Arecaceae,Palm,exotic,1086152,http://eol.org/pages/1086152/overview,not listed,not listed,,"little, none",palm,evergreen,,,
-Olea europaea,OLIVE,87,Oleaceae,Olive,exotic,579181,http://eol.org/pages/579181/overview,Data Deficient,Data Deficient,http://www.iucnredlist.org/details/summary/63005/1,filtered,"rounded, vase",evergreen,limited,https://www.cal-ipc.org/plants/paf/olea-europaea-plant-assessment-form/,minimal
+Olea europaea,OLIVE,87,Oleaceae,Olive,limited,579181,http://eol.org/pages/579181/overview,Data Deficient,Data Deficient,http://www.iucnredlist.org/details/summary/63005/1,filtered,"rounded, vase",evergreen,limited,https://www.cal-ipc.org/plants/paf/olea-europaea-plant-assessment-form/,minimal
 Other tree,Other Tree,203,,,exotic,,,not listed,not listed,,,,,,,
 Palm spp.,PALM,90,Arecaceae,Palm,exotic,8193,http://eol.org/pages/8193/overview,not listed,not listed,,"little, none",palm,evergreen,,,
 Parkinsonia X 'Desert Museum',Desert Museum Palo Verde,677,Fabaceae,Legume,exotic,53527,http://eol.org/pages/53527/overview,not listed,not listed,,"little, none",palm,evergreen,,,
 Persea americana,AVOCADO,8,Lauraceae,Laurel,exotic,596888,http://eol.org/pages/596888/overview,Least Concern,Least Concern,http://www.iucnredlist.org/details/96986556/0,filtered,rounded,evergreen,,,moderate
 Persea borbonia,RED BAY,316,Lauraceae,Laurel,exotic,596915,http://eol.org/pages/596915/overview,not listed,not listed,,filtered,rounded,evergreen,,,moderate
 Persea indica,Madeira Bay Fig,911,Lauraceae,Laurel,exotic,5394782,http://eol.org/pages/5394782/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2017-3.RLTS.T30329A102153566.en,filtered,rounded,evergreen,,,
-Phoenix canariensis,CANARY ISLAND DATE PALM,25,Arecaceae,Palm,exotic,1135089,http://eol.org/pages/1135089/overview,Least Concern,Least Concern,http://www.iucnredlist.org/details/13416997/0,little,,,limited,https://www.cal-ipc.org/plants/paf/phoenix-canariensis-plant-assessment-form/,minimal
+Phoenix canariensis,CANARY ISLAND DATE PALM,25,Arecaceae,Palm,limited,1135089,http://eol.org/pages/1135089/overview,Least Concern,Least Concern,http://www.iucnredlist.org/details/13416997/0,little,,,limited,https://www.cal-ipc.org/plants/paf/phoenix-canariensis-plant-assessment-form/,minimal
 Phoenix dactylifera,DATE PALM,162,Arecaceae,Palm,exotic,1135088,http://eol.org/pages/1135088/overview,Least Concern,Least Concern,http://www.iucnredlist.org/details/13416997/0,little,,,,,moderate
 Phoenix reclinata,SENEGAL PALM,218,Arecaceae,Palm,exotic,1135083,http://eol.org/pages/1135083/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2017-3.RLTS.T67540526A67540546.en,"little, none",palm,evergreen,,,
 Phoenix roebelenii,PYGMY DATE PALM,324,Arecaceae,Palm,exotic,1135082,http://eol.org/pages/1135082/overview,not listed,not listed,,"little, none",palm,evergreen,,,moderate
@@ -218,7 +218,7 @@ Pistacia chinensis,CHINESE PISTACHE,34,Anacardiaceae,Sumac,exotic,483509,http://
 Pittosporum crassifolium,KARO,322,Pittosporaceae,Cheesewood,exotic,486199,http://eol.org/pages/486199/overview,not listed,not listed,,dense,rounded,evergreen,,,moderate
 Pittosporum phillyraeoides,WILLOW PITTOSPORUM,244,Pittosporaceae,Cheesewood,exotic,5555698,https://eol.org/pages/5555698/overview,not listed,not listed,,filtered,"weeping, rounded",evergreen,,,moderate
 Pittosporum tobira,MOCK ORANGE,198,Pittosporaceae,Cheesewood,exotic,583390,http://eol.org/pages/583390/overview,not listed,not listed,,dense,rounded,evergreen,,,moderate
-Pittosporum undulatum,VICTORIAN BOX,125,Pittosporaceae,Cheesewood,exotic,583391,http://eol.org/pages/583391/overview,not listed,not listed,,dense,rounded,evergreen,watch,https://www.cal-ipc.org/plants/risk/pittosporum-undulatum-risk/,moderate
+Pittosporum undulatum,VICTORIAN BOX,125,Pittosporaceae,Cheesewood,watch,583391,http://eol.org/pages/583391/overview,not listed,not listed,,dense,rounded,evergreen,watch,https://www.cal-ipc.org/plants/risk/pittosporum-undulatum-risk/,moderate
 Pittosporum viridiflorum,CAPE PITTOSPORUM,345,Pittosporaceae,Cheesewood,exotic,47136685,https://eol.org/pages/47136685/overview,not listed,not listed,,dense,rounded,evergreen,,,moderate
 Platanus mexicana,Mexican Sycamore,440,Platanaceae,Plane-tree,exotic,5348089,http://eol.org/pages/5348089/overview,not listed,not listed,,dense,"vase, spreading",,,,
 Platanus racemosa,CALIFORNIA SYCAMORE,23,Platanaceae,Plane-tree,native,594707,http://eol.org/pages/594707/overview,not listed,not listed,,filtered,spreading,evergreen,,,
@@ -231,10 +231,10 @@ Prosopis glandulosa,Mesquite,905,Fabaceae,Legume,native,416627,http://eol.org/pa
 Prunus armeniaca,APRICOT,6,Rosaceae,Rose,exotic,301091,http://eol.org/pages/301091/overview,Endangered,"Endangered B2ab(iii)",http://dx.doi.org/10.2305/IUCN.UK.2007.RLTS.T63405A12666025.en,filtered,"Rounded, Spreading, Vase",deciduous,,,moderate
 Prunus blireiana,FLOWERING PLUM,47,Rosaceae,Rose,exotic,39934521,https://eol.org/pages/39934521,not listed,not listed,,filtered,,,,,moderate
 Prunus caroliniana,CAROLINA LAUREL CHERRY,28,Rosaceae,Rose,exotic,301110,http://eol.org/pages/301110/overview,not listed,not listed,,dense,rounded,evergreen,,,
-Prunus cerasifera,PURPLE-LEAF PLUM,98,Rosaceae,Rose,exotic,301112,https://eol.org/pages/301112/overview,Data Deficient,Data Deficient,http://www.iucnredlist.org/details/172162/1,dense,"rounded, vase",deciduous,limited,https://www.cal-ipc.org/plants/paf/prunus-cerasifera-plant-assessment-form/,moderate
-Prunus cerasifera 'Atropurpurea',Purple-Leaf Flowering Plum,683,Rosaceae,Rose,exotic,301112,https://eol.org/pages/301112/overview,not listed,not listed,,dense,"rounded, vase",deciduous,limited,https://www.cal-ipc.org/plants/paf/prunus-cerasifera-plant-assessment-form/,moderate
-Prunus cerasifera 'Krater Vesuvius',PLUM KRAUTERS VESUVIUS,1371,Rosaceae,Rose,exotic,301112,https://eol.org/pages/301112/overview,not listed,not listed,,dense,rounded,deciduous,limited,https://www.cal-ipc.org/plants/paf/prunus-cerasifera-plant-assessment-form/,moderate
-Prunus cerasifera 'Newport',Newport Plum,397,Rosaceae,Rose,exotic,301112,https://eol.org/pages/301112/overview,not listed,not listed,,dense,"rounded, vase",deciduous,limited,https://www.cal-ipc.org/plants/paf/prunus-cerasifera-plant-assessment-form/,moderate
+Prunus cerasifera,PURPLE-LEAF PLUM,98,Rosaceae,Rose,limited,301112,https://eol.org/pages/301112/overview,Data Deficient,Data Deficient,http://www.iucnredlist.org/details/172162/1,dense,"rounded, vase",deciduous,limited,https://www.cal-ipc.org/plants/paf/prunus-cerasifera-plant-assessment-form/,moderate
+Prunus cerasifera 'Atropurpurea',Purple-Leaf Flowering Plum,683,Rosaceae,Rose,limited,301112,https://eol.org/pages/301112/overview,not listed,not listed,,dense,"rounded, vase",deciduous,limited,https://www.cal-ipc.org/plants/paf/prunus-cerasifera-plant-assessment-form/,moderate
+Prunus cerasifera 'Krater Vesuvius',PLUM KRAUTERS VESUVIUS,1371,Rosaceae,Rose,limited,301112,https://eol.org/pages/301112/overview,not listed,not listed,,dense,rounded,deciduous,limited,https://www.cal-ipc.org/plants/paf/prunus-cerasifera-plant-assessment-form/,moderate
+Prunus cerasifera 'Newport',Newport Plum,397,Rosaceae,Rose,limited,301112,https://eol.org/pages/301112/overview,not listed,not listed,,dense,"rounded, vase",deciduous,limited,https://www.cal-ipc.org/plants/paf/prunus-cerasifera-plant-assessment-form/,moderate
 Prunus domestica,PLUM,95,Rosaceae,Rose,exotic,301139,http://eol.org/pages/301139/overview,Data Deficient,Data Deficient,http://dx.doi.org/10.2305/IUCN.UK.2017-3.RLTS.T50135950A50135957.en,filtered,"rounded, spreading",deciduous,,,moderate
 Prunus ilicifolia,Hollyleaf Cherry,181,Rosaceae,Rose,native,11165073,http://eol.org/pages/11165073/overview,not listed,not listed,,dense,spreading,evergreen,,,
 Prunus ilicifolia ssp. Lyonii,CATALINA CHERRY,156,Rosaceae,Rose,native,1245549,http://eol.org/pages/1245549/overview,not listed,not listed,,dense,"spreading, vase",evergreen,,,moderate
@@ -242,7 +242,7 @@ Prunus lusitanica,Portugal Laurel,1374,Rosaceae,Rose,exotic,640257,http://eol.or
 Prunus persica,PEACH,91,Rosaceae,Rose,exotic,631649,http://eol.org/pages/631649/overview,not listed,not listed,,filtered,rounded,deciduous,,,moderate
 Prunus spp.,Stone Fruit,118,Rosaceae,Rose,exotic,39934521,https://eol.org/pages/39934521,not listed,not listed,,filtered,,,,,
 Psidium guajava,GUAVA,268,Myrtaceae,Myrtle,exotic,2508593,http://eol.org/pages/2508593/overview,not listed,not listed,,filtered,"rounded, vase","evergreen, semi-deciduous",,,
-Pyrus calleryana,ORNAMENTAL PEAR,89,Rosaceae,Rose,exotic,299081,http://eol.org/pages/299081/overview,not listed,not listed,,dense,rounded,deciduous,watch,https://www.cal-ipc.org/plants/risk/pyrus-calleryana-risk/,moderate
+Pyrus calleryana,ORNAMENTAL PEAR,89,Rosaceae,Rose,watch,299081,http://eol.org/pages/299081/overview,not listed,not listed,,dense,rounded,deciduous,watch,https://www.cal-ipc.org/plants/risk/pyrus-calleryana-risk/,moderate
 Pyrus kawakamii,EVERGREEN PEAR,45,Rosaceae,Rose,exotic,49271488,https://eol.org/pages/49271488,not listed,not listed,,filtered,"pendulous, spreading","evergreen, semi-deciduous",,,moderate
 Quercus agrifolia,COAST LIVE OAK,68,Fagaceae,Beech,native,1151806,http://eol.org/pages/1151806/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2016-1.RLTS.T194049A2295175.en,dense,"rounded, spreading",evergreen,,,minimal
 Quercus engelmannii,ENGELMANN OAK,359,Fagaceae,Beech,native,1151633,http://www.eol.org/pages/1151633/overview,Endangered,Endangered A3c,http://www.iucnredlist.org/details/34020/0,dense,vase,,,,
@@ -256,7 +256,7 @@ Ravenea rivularis,MAJESTY PALM,342,Arecaceae,Palm,exotic,1131993,http://eol.org/
 Rhus lancea,AFRICAN SUMAC,138,Anacardiaceae,Sumac,exotic,582276,https://eol.org/pages/582276/overview,not listed,not listed,,dense,"pendulous, rounded",evergreen,,,
 Rhus laurina,Laurel Sumac,579,Anacardiaceae,Sumac,native,486956,https://eol.org/pages/486956/overview,not listed,not listed,,,,evergreen,,,
 Robinia ambigua 'Idahoensis',Idaho Locust,185,Fabaceae,Legume,exotic,49133015,https://eol.org/pages/49133015,not listed,not listed,,filtered,vase,deciduous,,,
-Robinia pseudoacacia,Black Locust,10,Fabaceae,Legume,exotic,704089,http://eol.org/pages/704089/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2012.RLTS.T19891648A20138922.en,filtered,spreading,deciduous,limited,https://www.cal-ipc.org/plants/paf/robinia-pseudoacacia-plant-assessment-form/,
+Robinia pseudoacacia,Black Locust,10,Fabaceae,Legume,limited,704089,http://eol.org/pages/704089/overview,Least Concern,Least Concern,http://dx.doi.org/10.2305/IUCN.UK.2012.RLTS.T19891648A20138922.en,filtered,spreading,deciduous,limited,https://www.cal-ipc.org/plants/paf/robinia-pseudoacacia-plant-assessment-form/,
 Roystonea regia,CUBAN ROYAL PALM,470,Arecaceae,Palm,exotic,1131526,http://eol.org/pages/1131526/overview,not listed,not listed,,"little, none",palm,evergreen,,,moderate
 Salix babylonica,WEEPING WILLOW,240,Salicaceae,Willow,exotic,47108280,https://eol.org/pages/47108280/overview,not listed,not listed,,"filtered, dense",weeping,deciduous,,,
 Schefflera actinophylla,QUEENSLAND UMBRELLA TREE,328,Araliaceae,Ginseng,exotic,1150882,http://eol.org/pages/1150882/overview,not listed,not listed,,"filtered, dense",,,,,moderate
@@ -291,7 +291,7 @@ Vacant site,VACANT SITE,238,,,,,,not listed,not listed,,,,,,,
 Viburnum spp.,Viburnum,571,Adoxaceae,Adoxas,exotic,490016,https://eol.org/pages/490016/overview,not listed,not listed,,dense,,,,,moderate
 Washingtonia filifera,CALIFORNIA FAN PALM,21,Arecaceae,Palm,native,1127834,http://www.eol.org/pages/1127834/overview,Lower Risk/near threatened,Lower Risk/near threatened,http://dx.doi.org/10.2305/IUCN.UK.1998.RLTS.T38725A10145920.en,little,,,,,"none, once established"
 Washingtonia filifera X robusta,Filibuster Hybrid Fan Palm,557,Arecaceae,Palm,exotic,,,not listed,not listed,,"little, none",palm,evergreen,,,"none, once established"
-Washingtonia robusta,MEXICAN FAN PALM,75,Arecaceae,Palm,exotic,1127833,http://eol.org/pages/1127833/overview,Lower Risk/near threatened,Lower Risk/near threatened,http://dx.doi.org/10.2305/IUCN.UK.1998.RLTS.T38725A10145920.en,little,,,moderate,https://www.cal-ipc.org/plants/paf/washingtonia-robusta-plant-assessment-form/,"none, once established"
+Washingtonia robusta,MEXICAN FAN PALM,75,Arecaceae,Palm,moderate,1127833,http://eol.org/pages/1127833/overview,Lower Risk/near threatened,Lower Risk/near threatened,http://dx.doi.org/10.2305/IUCN.UK.1998.RLTS.T38725A10145920.en,little,,,moderate,https://www.cal-ipc.org/plants/paf/washingtonia-robusta-plant-assessment-form/,"none, once established"
 Wisteria sinensis,CHINESE WISTERIA,662,Fabaceae,Legume,exotic,704193,http://eol.org/pages/704193/overview,not listed,not listed,,filtered,vine,,,,
 Wodyetia bifurcata,FOXTAIL PALM,604,Arecaceae,Palm,exotic,1127809,http://eol.org/pages/1127809/overview,Lower Risk/conservation dependent,Lower Risk/conservation dependent,http://dx.doi.org/10.2305/IUCN.UK.1998.RLTS.T38733A10146773.en,"little, none",palm,evergreen,,,moderate
 Yucca elephantipes,Giant Yucca,224,Asparagaceae,Asparagus,exotic,1083612,https://eol.org/pages/1083612/overview,not listed,not listed,,filtered,palm,evergreen,,,"none, once established"


### PR DESCRIPTION
<!-- if the linked issue should remain open after your PR is merged: -->
addresses #[171](https://github.com/Public-Tree-Map/public-tree-map/issues/171)

# Motivation and context
- <!-- please describe what problem your issue is solving --> this PR updates the "species attributes" data to allow trees designated as invasive to appear as part of the native/non-native view (rather than in a separate view/palette)

- this PR needs a companion one in the other repository (to update palettes and fix the language that appears in the sidebar - should still read something like "this species isn't native to california")

# What I did
- <!-- list summary of changes made in this PR --> for each species/variety designated by cal_ipc as invasive, I listed the cal_ipc status in the species attributes csv "native" field
