### PR TITLE
apt-get-update in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: google/cloud-sdk:latest
     steps:
       - checkout
+      - run: apt-get update
       - run: apt-get install -y build-essential
       - run: curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
       - run: ./python-env.sh


### PR DESCRIPTION
runs apt-get to prevent version errors