### PR TITLE
uploading to google storage only on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,7 @@ jobs:
       - run: nvm use 9.11.1
       - run: npm install
       - run: make release
-      - run: |
-          echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-          gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
-      - run: gsutil cp -Z build/data/map.json gs://public-tree-map/data/
-      - run: gsutil -m cp -Z build/data/trees/*.json gs://public-tree-map/data/trees/
-      - run: gsutil setmeta -h "Cache-Control:public, max-age=43200" gs://public-tree-map/data/map.json
-      - run: gsutil -m setmeta -h "Cache-Control:public, max-age=43200" gs://public-tree-map/data/trees/*.json
-      - run: gsutil -m cp -r build/img gs://public-tree-map/
+      - run: scripts/upload_trees_google_storage.sh "${GCLOUD_SERVICE_KEY}" "${GOOGLE_PROJECT_ID}" "${CIRCLE_BRANCH}"
 
       - store_artifacts:
           path: tmp/log.txt

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,6 @@ find-missing-species:
 # Removes build artifacts
 clean:
 	rm -rf build
+
+circleci-local: clean
+	circleci local execute --job deploy

--- a/scripts/upload_trees_google_storage.sh
+++ b/scripts/upload_trees_google_storage.sh
@@ -20,8 +20,12 @@ GCLOUD_SERVICE_KEY="${1:-}"
 GOOGLE_PROJECT_ID="${2:-}"
 BRANCH_NAME="${3}"
 
-if [[ "${BRANCH_NAME}" == 'master' && "${GCLOUD_SERVICE_KEY}" != '' && "${GOOGLE_PROJECT_ID}" != '' ]]; then
-  upload_google_cloud "${GCLOUD_SERVICE_KEY}" "${GOOGLE_PROJECT_ID}"
+if [[ "${BRANCH_NAME}" == 'master' ]]; then
+  if [[ "${GCLOUD_SERVICE_KEY}" != '' && "${GOOGLE_PROJECT_ID}" != '' ]]; then
+    upload_google_cloud "${GCLOUD_SERVICE_KEY}" "${GOOGLE_PROJECT_ID}"
+  else
+    echo either GOOGLE_PROJECT_ID or GCLOUD_SERVICE_KEY has not been specified.
+  fi
 else
   echo "${BRANCH_NAME}" does not support pushing to google storage.
 fi

--- a/scripts/upload_trees_google_storage.sh
+++ b/scripts/upload_trees_google_storage.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o errexit  # abort on nonzero exitstatus
+set -o nounset  # abort on unbound variable
+set -o pipefail # don't hide errors within pipes
+
+function upload_google_cloud() {
+  gcloud_service_key="${1}"
+  google_project_id="${2}"
+  echo "${gcloud_service_key}" | gcloud auth activate-service-account --key-file=-
+  gcloud --quiet config set project "${google_project_id}"
+  gsutil cp -Z build/data/map.json gs://public-tree-map/data/
+  gsutil -m cp -Z build/data/trees/*.json gs://public-tree-map/data/trees/
+  gsutil setmeta -h "Cache-Control:public, max-age=43200" gs://public-tree-map/data/map.json
+  gsutil -m setmeta -h "Cache-Control:public, max-age=43200" gs://public-tree-map/data/trees/*.json
+  gsutil -m cp -r build/img gs://public-tree-map/
+}
+
+GCLOUD_SERVICE_KEY="${1:-}"
+GOOGLE_PROJECT_ID="${2:-}"
+BRANCH_NAME="${3}"
+
+if [[ "${BRANCH_NAME}" == 'master' && "${GCLOUD_SERVICE_KEY}" != '' && "${GOOGLE_PROJECT_ID}" != '' ]]; then
+  upload_google_cloud "${GCLOUD_SERVICE_KEY}" "${GOOGLE_PROJECT_ID}"
+else
+  echo "${BRANCH_NAME}" does not support pushing to google storage.
+fi


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #85 

only uploads tree data to google cloud when building the master branch.

# Motivation and context
don't want to override "prod" data affecting the website when testing.

# Screenshots
| before | after |
|---|---|
to be shot ...

# What I did
- refactored the push step into a script
- only push files when building the master branch.
