### PR TITLE
updating miniconda download url

### DIFF
--- a/python-env.sh
+++ b/python-env.sh
@@ -1,4 +1,4 @@
-curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh;
+curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 conda config --set always_yes yes --set changeps1 no


### PR DESCRIPTION
# Motivation and context
The builds had recently been breaking: https://app.circleci.com/pipelines/github/Public-Tree-Map/public-tree-map-data-pipeline/384/workflows/c05fd2e0-7fe3-4274-a413-09d70ee1a581/jobs/790

This was due to an out of date url to download miniconda (python environment).

# Screenshots
Before:

Here is the root of the problem (not downloading conda so it doesn't exist):
![Screen Shot 2020-04-09 at 7 56 03 PM](https://user-images.githubusercontent.com/13500774/78958362-b1852000-7a9c-11ea-8507-f7a3c9062771.png)

After:

This shows a glimpse of the local builds downloading conda successfully:
![Screen Shot 2020-04-09 at 7 55 39 PM](https://user-images.githubusercontent.com/13500774/78958232-56ebc400-7a9c-11ea-9870-8664ae996afd.png)

Also take a look at a previous successful build to compare (./python-env.sh step): https://app.circleci.com/pipelines/github/Public-Tree-Map/public-tree-map-data-pipeline/383/workflows/e9af3410-614e-4b22-a4bb-bb20bfd4dc3f/jobs/788

This shows the local build succeeding after my change:
![Screen Shot 2020-04-09 at 7 55 15 PM](https://user-images.githubusercontent.com/13500774/78958192-43d8f400-7a9c-11ea-940d-a734d124cd25.png)

# What I did
- updated the miniconda download url to point to a working download link.
