### PR TITLE
Bump node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
       - run: echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV
       - run: echo 'export PATH="$HOME/miniconda/bin:$PATH"' >> $BASH_ENV
       - run: echo 'source activate public-tree-map' >> $BASH_ENV
-      - run: nvm install 9.11.1
-      - run: nvm use 9.11.1
+      - run: nvm install 10.15.1
+      - run: nvm use 10.15.1
       - run: npm install
       - run: make release
       - run: scripts/upload_trees_google_storage.sh "${GCLOUD_SERVICE_KEY}" "${GOOGLE_PROJECT_ID}" "${CIRCLE_BRANCH}"

--- a/download-images.js
+++ b/download-images.js
@@ -32,6 +32,10 @@ const log      = require('./util.js').log
 const mkdir    = require('./util.js').mkdir
 const stdin    = require('./util.js').stdin
 
+const stream      = require('stream')
+const {promisify} = require('util')
+const pipeline    = promisify(stream.pipeline)
+
 async function main() {
   let trees = JSON.parse(stdin())
 
@@ -86,9 +90,10 @@ async function processImage(data, eolId, index) {
   mkdir('build')
   mkdir('build/img')
 
-  await new Promise(resolve => {
-    got.stream(imgUrl).pipe(fs.createWriteStream(filepath)).on('finish', resolve)
-  })
+  await pipeline(
+    got.stream(imgUrl),
+    fs.createWriteStream(filepath)
+  )
 
   let resizedData = await sharp(filepath).resize(1024, 1024, { fit: 'inside' })
                                          .toBuffer()

--- a/download-images.js
+++ b/download-images.js
@@ -42,6 +42,7 @@ async function main() {
   log('== Starting image downloads...')
 
   let images = {}
+  mkdir('build/img')
 
   trees.filter(t => t.eol_id > 0)
        .forEach(t => images[t.eol_id] = '')
@@ -87,8 +88,6 @@ async function processImage(data, eolId, index) {
     url : `https://eol.org/pages/${eolId}/media`,
   }
 
-  mkdir('build')
-  mkdir('build/img')
 
   await pipeline(
     got.stream(imgUrl),


### PR DESCRIPTION
Looks like node 9.11 is somehow causing the image download script to fail. 

Bumping node to 10.15.1 fixes this problem. Node 10 will be maintained till April 2021.